### PR TITLE
Separate the PHP Prettier configuration

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# Top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+max_line_length = 120
+trim_trailing_whitespace = true

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,6 @@
 module.exports = {
   // Extends the UdeS ESLint config for Node.js 12 application
-  extends: 'eslint-config-udes',
+  extends: 'eslint-config-udes/node-12',
 
   // Limit ESLint to a specific project
   root: true,

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 Université de Sherbrooke
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ package.json:
 {
   "prettier": "prettier-config-udes/php",
   "scripts": {
-    "format:prettier": "prettier --ignore-path .gitignore --write '**/*.{css,html,js,json,md,scss,yaml,yml}'",
-    "lint:prettier": "prettier --ignore-path .gitignore --check '**/*.{css,html,js,json,md,scss,yaml,yml}'"
+    "format:prettier": "prettier --ignore-path .gitignore --write '**/*.{css,html,js,json,md,php,scss,yaml,yml}'",
+    "lint:prettier": "prettier --ignore-path .gitignore --check '**/*.{css,html,js,json,md,php,scss,yaml,yml}'"
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ Edit `package.json`:
 {
   "prettier": "prettier-config-udes",
   "scripts": {
-    "format:prettier": "prettier --ignore-path .gitignore --write '**/*.{css,html,js,json,md,php,scss,yaml,yml}'",
-    "lint:prettier": "prettier --ignore-path .gitignore --check '**/*.{css,html,js,json,md,php,scss,yaml,yml}'"
+    "format:prettier": "prettier --ignore-path .gitignore --write '**/*.{css,html,js,json,md,scss,yaml,yml}'",
+    "lint:prettier": "prettier --ignore-path .gitignore --check '**/*.{css,html,js,json,md,scss,yaml,yml}'"
   }
 }
 ```
@@ -39,6 +39,21 @@ Else, Prettier will output an error:
 
 ```
 [error] No files matching the pattern were found: "**/*.css".
+```
+
+### PHP
+
+If you want to be able to format **PHP** files, you must extends our PHP Prettier configuration by editing your
+package.json:
+
+```json
+{
+  "prettier": "prettier-config-udes/php",
+  "scripts": {
+    "format:prettier": "prettier --ignore-path .gitignore --write '**/*.{css,html,js,json,md,scss,yaml,yml}'",
+    "lint:prettier": "prettier --ignore-path .gitignore --check '**/*.{css,html,js,json,md,scss,yaml,yml}'"
+  }
+}
 ```
 
 ## Publish

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prettier-config-udes",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Prettier shareable config for the UdeS style guide",
   "keywords": [
     "udes",
@@ -25,7 +25,8 @@
   "author": "Université de Sherbrooke",
   "main": "index.js",
   "files": [
-    "index.js"
+    "index.js",
+    "php.js"
   ],
   "scripts": {
     "format": "npm-run-all format:*",
@@ -44,18 +45,20 @@
     }
   },
   "dependencies": {
-    "@prettier/plugin-php": "^0.14.3",
-    "prettier": "^2.0.5"
+    "prettier": "^2.1.2"
   },
   "devDependencies": {
-    "eslint-config-udes": "^0.4.1",
+    "eslint-config-udes": "^0.4.2",
     "eslint-plugin-json-format": "^2.0.1",
     "eslint-plugin-markdown": "^1.0.2",
     "eslint-plugin-prettier": "^3.1.4",
-    "husky": "^4.2.5",
-    "lint-staged": "^10.2.11",
+    "husky": "^4.3.0",
+    "lint-staged": "^10.4.0",
     "npm-run-all": "^4.1.5",
-    "snyk": "^1.381.1"
+    "snyk": "^1.406.0"
+  },
+  "peerDependencies": {
+    "@prettier/plugin-php": "^0.14.3"
   },
   "snyk": true
 }

--- a/php.js
+++ b/php.js
@@ -1,0 +1,22 @@
+const udesPrettierConfig = require('./index.js');
+
+/**
+ * Prettier configuration file
+ */
+module.exports = {
+  // Extends the UdeS Prettier configuration file
+  ...udesPrettierConfig,
+
+  /**
+   * Options from the the PHP plugin
+   * See https://github.com/prettier/plugin-php
+   */
+  // Prettier will move open brace for code blocks (classes, functions and methods) onto same line
+  braceStyle: '1tbs', // Default: "psr-2"
+
+  // PHP version we are currently using
+  phpVersion: '7.3', // Default: "5.4"
+
+  // Trailing commas will be added wherever possible
+  trailingCommaPHP: true, // Default: true
+};


### PR DESCRIPTION
To not include the dependency when a project doesn't have any PHP files.

I also create the `.editorconfig` and `LICENSE.md` files to be coherent with `eslint-config-udes` code and I have updated the dependencies.