### PR TITLE
Miscellaneous fixes

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,6 @@
 module.exports = {
-  // Extends the UdeS ESLint config for Node.js 12 application
-  extends: 'eslint-config-udes/node-12',
+  // Extends the UdeS ESLint config for Node.js 16 application
+  extends: 'eslint-config-udes/node-16',
 
   // Limit ESLint to a specific project
   root: true,

--- a/.snyk
+++ b/.snyk
@@ -2,21 +2,4 @@
 version: v1.14.1
 ignore: {}
 # patches apply the minimum changes required to fix a vulnerability
-patch:
-  SNYK-JS-LODASH-567746:
-    - eslint-plugin-json-format > lodash:
-        patched: '2020-05-13T12:54:35.304Z'
-    - eslint-config-udes > eslint > lodash:
-        patched: '2020-05-13T12:54:35.304Z'
-    - eslint-config-udes > babel-eslint > @babel/traverse > lodash:
-        patched: '2020-05-13T12:54:35.304Z'
-    - eslint-config-udes > eslint > inquirer > lodash:
-        patched: '2020-05-13T12:54:35.304Z'
-    - eslint-config-udes > eslint > table > lodash:
-        patched: '2020-05-13T12:54:35.304Z'
-    - eslint-config-udes > babel-eslint > @babel/traverse > @babel/generator > lodash:
-        patched: '2020-05-13T12:54:35.304Z'
-    - eslint-config-udes > babel-eslint > @babel/traverse > @babel/helper-split-export-declaration > @babel/types > lodash:
-        patched: '2020-05-13T12:54:35.304Z'
-    - eslint-config-udes > babel-eslint > @babel/traverse > @babel/helper-function-name > @babel/template > @babel/types > lodash:
-        patched: '2020-05-13T12:54:35.304Z'
+patch: {}

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 Université de Sherbrooke
+Copyright (c) 2021 Université de Sherbrooke
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Edit `package.json`:
 {
   "prettier": "prettier-config-udes",
   "scripts": {
-    "format:prettier": "prettier --ignore-path .gitignore --write '**/*.{css,html,js,json,md,scss,yaml,yml}'",
+    "format:prettier": "npm run lint:prettier -- --write",
     "lint:prettier": "prettier --ignore-path .gitignore --check '**/*.{css,html,js,json,md,scss,yaml,yml}'"
   }
 }
@@ -43,7 +43,7 @@ Else, Prettier will output an error:
 
 ### PHP
 
-If you want to be able to format **PHP** files, you must extends our PHP Prettier configuration by editing your
+If you want to be able to format **PHP** files, you must extend our PHP Prettier configuration by editing your
 package.json:
 
 ```json

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prettier-config-udes",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Prettier shareable config for the UdeS style guide",
   "keywords": [
     "udes",
@@ -54,9 +54,9 @@
     "eslint-plugin-markdown": "^2.2.1",
     "eslint-plugin-prettier": "^4.0.0",
     "husky": "^7.0.2",
-    "lint-staged": "^11.1.2",
+    "lint-staged": "^11.2.0",
     "npm-check-updates": "^11.8.5",
     "npm-run-all": "^4.1.5",
-    "snyk": "^1.720.0"
+    "snyk": "^1.733.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -49,14 +49,14 @@
     "prettier": "^2.4.1"
   },
   "devDependencies": {
-    "eslint-config-udes": "^1.1.0",
+    "eslint-config-udes": "^1.2.0",
     "eslint-plugin-json-format": "^2.0.1",
     "eslint-plugin-markdown": "^2.2.1",
     "eslint-plugin-prettier": "^4.0.0",
     "husky": "^7.0.2",
-    "lint-staged": "^11.1.2",
+    "lint-staged": "^11.2.3",
     "npm-check-updates": "^11.8.5",
     "npm-run-all": "^4.1.5",
-    "snyk": "^1.720.0"
+    "snyk": "^1.735.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prettier-config-udes",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Prettier shareable config for the UdeS style guide",
   "keywords": [
     "udes",
@@ -36,7 +36,8 @@
     "lint:eslint": "eslint --ignore-path .gitignore . --ext js,json,md",
     "lint:prettier": "prettier --ignore-path .gitignore --config=index.js --check '**/*.{js,json,md}'",
     "prepublish": "npm run snyk-protect",
-    "snyk-protect": "snyk protect"
+    "snyk-protect": "snyk protect",
+    "update": "ncu -u && npm i && npm audit fix"
   },
   "husky": {
     "hooks": {
@@ -45,20 +46,17 @@
     }
   },
   "dependencies": {
-    "prettier": "^2.2.1"
+    "prettier": "^2.4.1"
   },
   "devDependencies": {
-    "eslint-config-udes": "^0.4.3",
+    "eslint-config-udes": "^1.1.0",
     "eslint-plugin-json-format": "^2.0.1",
-    "eslint-plugin-markdown": "^1.0.2",
-    "eslint-plugin-prettier": "^3.3.1",
-    "husky": "^5.0.9",
-    "lint-staged": "^10.5.4",
+    "eslint-plugin-markdown": "^2.2.1",
+    "eslint-plugin-prettier": "^4.0.0",
+    "husky": "^7.0.2",
+    "lint-staged": "^11.1.2",
+    "npm-check-updates": "^11.8.5",
     "npm-run-all": "^4.1.5",
-    "snyk": "^1.454.0"
-  },
-  "peerDependencies": {
-    "@prettier/plugin-php": "^0.16.1"
-  },
-  "snyk": true
+    "snyk": "^1.720.0"
+  }
 }

--- a/php.js
+++ b/php.js
@@ -8,7 +8,7 @@ module.exports = {
   ...udesPrettierConfig,
 
   /**
-   * Options from the the PHP plugin
+   * Options from the PHP plugin
    * See https://github.com/prettier/plugin-php
    */
   // Prettier will move open brace for code blocks (classes, functions and methods) onto same line


### PR DESCRIPTION
- Use the `Node 16` ESLint configuration (should be available on the next release of `eslint-config-udes` (after https://github.com/UdeS-STI/eslint-config-udes/pull/43)
- Update the `format:prettier` script in README.md to simplify it
- Fix minor typos